### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@
 /TestApplication_RAWSerialization.Tests/obj/Debug
 /TestApplication_RAWSerializationWithoutTypeReference/bin
 /TestApplication_RAWSerializationWithoutTypeReference/obj/Debug
+.vs
+TestApplication_PersonalizedHelpers/obj
+UpgradeLog.htm
+UpgradeLog2.htm

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,11 @@
 TestApplication_PersonalizedHelpers/obj
 UpgradeLog.htm
 UpgradeLog2.htm
+/MongoSessionStateStore/Core/Compression
+/TestApplication_PersonalizedHelpers/Core/Compression
+/TestApplication_PersonalizedHelpers/mongocrypt.dll
+/TestApplication_PersonalizedHelpers/libmongocrypt.so
+/TestApplication_PersonalizedHelpers/libmongocrypt.dylib
+/MongoSessionStateStore/mongocrypt.dll
+/MongoSessionStateStore/libmongocrypt.so
+/MongoSessionStateStore/libmongocrypt.dylib

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,14 @@ UpgradeLog2.htm
 /MongoSessionStateStore/mongocrypt.dll
 /MongoSessionStateStore/libmongocrypt.so
 /MongoSessionStateStore/libmongocrypt.dylib
+/MongoSessionStateStore/obj/Release
+/MongoSessionStateStore/bin/Release
+/TestApplicationv2_0/obj/Release
+/TestApplicationv2_0.Tests/obj/Release
+/TestApplicationv2_0.Tests/bin/Release
+/TestApplication_PersonalizedHelpers.Tests/obj/Release
+/TestApplication_PersonalizedHelpers.Tests/bin/Release
+/TestApplication_RAWSerialization/obj/Release
+/TestApplication_RAWSerialization.Tests/obj/Release
+/TestApplication_RAWSerialization.Tests/bin/Release
+/TestApplication_RAWSerializationWithoutTypeReference/obj/Release

--- a/MongoSessionStateStore.sln
+++ b/MongoSessionStateStore.sln
@@ -5,17 +5,17 @@ VisualStudioVersion = 12.0.30501.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoSessionStateStore", "MongoSessionStateStore\MongoSessionStateStore.csproj", "{2F0DD54F-6EF0-4DDD-9737-6D174B9E4E9D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplicationv2_0", "TestApplicationv2_0\TestApplicationv2_0.csproj", "{2498B537-7ECE-4066-B098-26588275B062}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplicationv2_0_", "TestApplicationv2_0\TestApplicationv2_0.csproj", "{2498B537-7ECE-4066-B098-26588275B062}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplicationv2_0.Tests", "TestApplicationv2_0.Tests\TestApplicationv2_0.Tests.csproj", "{DA8558A2-7942-463A-A84D-86D25903E47B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication_RAWSerialization", "TestApplication_RAWSerialization\TestApplication_RAWSerialization.csproj", "{13161286-7BFA-4290-A4A9-937156F53AF8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication_RAWSerialization_", "TestApplication_RAWSerialization\TestApplication_RAWSerialization.csproj", "{13161286-7BFA-4290-A4A9-937156F53AF8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication_RAWSerialization.Tests", "TestApplication_RAWSerialization.Tests\TestApplication_RAWSerialization.Tests.csproj", "{1AC4B4D1-CDAF-4B9B-8BA8-0940CEF2E6FA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication_RAWSerializationWithoutTypeReference", "TestApplication_RAWSerializationWithoutTypeReference\TestApplication_RAWSerializationWithoutTypeReference.csproj", "{D8DD5EB3-1775-4F25-8165-6CFEFD3052A0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication_PersonalizedHelpers", "TestApplication_PersonalizedHelpers\TestApplication_PersonalizedHelpers.csproj", "{807CA175-FDD1-4DD0-9A65-87AEAA634D8E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication_PersonalizedHelpers_", "TestApplication_PersonalizedHelpers\TestApplication_PersonalizedHelpers.csproj", "{807CA175-FDD1-4DD0-9A65-87AEAA634D8E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication_PersonalizedHelpers.Tests", "TestApplication_PersonalizedHelpers.Tests\TestApplication_PersonalizedHelpers.Tests.csproj", "{693617CC-FEC3-4ED7-AAB9-B3674221881F}"
 EndProject

--- a/MongoSessionStateStore/MongoSessionStateStore.csproj
+++ b/MongoSessionStateStore/MongoSessionStateStore.csproj
@@ -51,9 +51,8 @@
     <Reference Include="MongoDB.Libmongocrypt, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Libmongocrypt.1.2.2\lib\net452\MongoDB.Libmongocrypt.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SharpCompress, Version=0.23.0.0, Culture=neutral, PublicKeyToken=afb0a02973931d96, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpCompress.0.23.0\lib\net45\SharpCompress.dll</HintPath>

--- a/MongoSessionStateStore/MongoSessionStateStore.csproj
+++ b/MongoSessionStateStore/MongoSessionStateStore.csproj
@@ -51,9 +51,6 @@
     <Reference Include="MongoDB.Libmongocrypt, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Libmongocrypt.1.2.2\lib\net452\MongoDB.Libmongocrypt.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="SharpCompress, Version=0.23.0.0, Culture=neutral, PublicKeyToken=afb0a02973931d96, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpCompress.0.23.0\lib\net45\SharpCompress.dll</HintPath>
     </Reference>

--- a/MongoSessionStateStore/MongoSessionStateStore.csproj
+++ b/MongoSessionStateStore/MongoSessionStateStore.csproj
@@ -13,6 +13,8 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,25 +36,44 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MongoDB.Bson, Version=2.2.2.10, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MongoDB.Bson.2.2.2\lib\net45\MongoDB.Bson.dll</HintPath>
+    <Reference Include="DnsClient, Version=1.4.0.0, Culture=neutral, PublicKeyToken=4574bb5573c51424, processorArchitecture=MSIL">
+      <HintPath>..\packages\DnsClient.1.4.0\lib\net45\DnsClient.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=2.2.2.10, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MongoDB.Driver.2.2.2\lib\net45\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.13.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.13.3\lib\net452\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver.Core, Version=2.2.2.10, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MongoDB.Driver.Core.2.2.2\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.13.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.13.3\lib\net452\MongoDB.Driver.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Core, Version=2.13.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.13.3\lib\net452\MongoDB.Driver.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Libmongocrypt, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Libmongocrypt.1.2.2\lib\net452\MongoDB.Libmongocrypt.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="SharpCompress, Version=0.23.0.0, Culture=neutral, PublicKeyToken=afb0a02973931d96, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpCompress.0.23.0\lib\net45\SharpCompress.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\netstandard1.1\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -74,11 +95,28 @@
     <Compile Include="SessionHelpers\SessionHelper.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="libmongocrypt.dylib" />
+    <None Include="libmongocrypt.so" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Core\Compression\Snappy\lib\win\snappy32.dll" />
+    <Content Include="Core\Compression\Snappy\lib\win\snappy64.dll" />
+    <Content Include="Core\Compression\Zstandard\lib\win\libzstd.dll" />
+    <Content Include="mongocrypt.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\MongoDB.Libmongocrypt.1.2.2\build\MongoDB.Libmongocrypt.targets" Condition="Exists('..\packages\MongoDB.Libmongocrypt.1.2.2\build\MongoDB.Libmongocrypt.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>Este proyecto hace referencia a los paquetes NuGet que faltan en este equipo. Use la restauración de paquetes NuGet para descargarlos. Para obtener más información, consulte http://go.microsoft.com/fwlink/?LinkID=322105. El archivo que falta es {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MongoDB.Libmongocrypt.1.2.2\build\MongoDB.Libmongocrypt.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MongoDB.Libmongocrypt.1.2.2\build\MongoDB.Libmongocrypt.targets'))" />
+    <Error Condition="!Exists('..\packages\MongoDB.Driver.Core.2.13.3\build\MongoDB.Driver.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MongoDB.Driver.Core.2.13.3\build\MongoDB.Driver.Core.targets'))" />
+  </Target>
+  <Import Project="..\packages\MongoDB.Driver.Core.2.13.3\build\MongoDB.Driver.Core.targets" Condition="Exists('..\packages\MongoDB.Driver.Core.2.13.3\build\MongoDB.Driver.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MongoSessionStateStore/MongoSessionStateStore.csproj
+++ b/MongoSessionStateStore/MongoSessionStateStore.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MongoSessionStateStore</RootNamespace>
     <AssemblyName>MongoSessionStateStore</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MongoSessionStateStore/packages.config
+++ b/MongoSessionStateStore/packages.config
@@ -5,7 +5,6 @@
   <package id="MongoDB.Driver" version="2.13.3" targetFramework="net452" />
   <package id="MongoDB.Driver.Core" version="2.13.3" targetFramework="net452" />
   <package id="MongoDB.Libmongocrypt" version="1.2.2" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net452" />
   <package id="SharpCompress" version="0.23.0" targetFramework="net452" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />

--- a/MongoSessionStateStore/packages.config
+++ b/MongoSessionStateStore/packages.config
@@ -5,7 +5,7 @@
   <package id="MongoDB.Driver" version="2.13.3" targetFramework="net452" />
   <package id="MongoDB.Driver.Core" version="2.13.3" targetFramework="net452" />
   <package id="MongoDB.Libmongocrypt" version="1.2.2" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net452" />
   <package id="SharpCompress" version="0.23.0" targetFramework="net452" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />

--- a/MongoSessionStateStore/packages.config
+++ b/MongoSessionStateStore/packages.config
@@ -1,7 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MongoDB.Bson" version="2.2.2" targetFramework="net45" />
-  <package id="MongoDB.Driver" version="2.2.2" targetFramework="net45" />
-  <package id="MongoDB.Driver.Core" version="2.2.2" targetFramework="net45" />
+  <package id="DnsClient" version="1.4.0" targetFramework="net452" />
+  <package id="MongoDB.Bson" version="2.13.3" targetFramework="net452" />
+  <package id="MongoDB.Driver" version="2.13.3" targetFramework="net452" />
+  <package id="MongoDB.Driver.Core" version="2.13.3" targetFramework="net452" />
+  <package id="MongoDB.Libmongocrypt" version="1.2.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net40" />
+  <package id="SharpCompress" version="0.23.0" targetFramework="net452" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>

--- a/MongoSessionStateStore/packages.config
+++ b/MongoSessionStateStore/packages.config
@@ -3,5 +3,5 @@
   <package id="MongoDB.Bson" version="2.2.2" targetFramework="net45" />
   <package id="MongoDB.Driver" version="2.2.2" targetFramework="net45" />
   <package id="MongoDB.Driver.Core" version="2.2.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net40" />
 </packages>

--- a/TestApplication_PersonalizedHelpers.Tests/App.config
+++ b/TestApplication_PersonalizedHelpers.Tests/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- 
     Nota: agregue entradas al archivo App.config para la configuración de la aplicación
     que solo se apliquen al proyecto de prueba.
@@ -11,4 +11,12 @@
     <connectionStrings>
 
     </connectionStrings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/TestApplication_PersonalizedHelpers.Tests/App.config
+++ b/TestApplication_PersonalizedHelpers.Tests/App.config
@@ -19,4 +19,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/TestApplication_PersonalizedHelpers.Tests/App.config
+++ b/TestApplication_PersonalizedHelpers.Tests/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- 
     Nota: agregue entradas al archivo App.config para la configuración de la aplicación
     que solo se apliquen al proyecto de prueba.
@@ -14,9 +14,9 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/TestApplication_PersonalizedHelpers.Tests/TestApplication_PersonalizedHelpers.Tests.csproj
+++ b/TestApplication_PersonalizedHelpers.Tests/TestApplication_PersonalizedHelpers.Tests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_PersonalizedHelpers.Tests</RootNamespace>
     <AssemblyName>TestApplication_PersonalizedHelpers.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/TestApplication_PersonalizedHelpers.Tests/TestApplication_PersonalizedHelpers.Tests.csproj
+++ b/TestApplication_PersonalizedHelpers.Tests/TestApplication_PersonalizedHelpers.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_PersonalizedHelpers.Tests</RootNamespace>
     <AssemblyName>TestApplication_PersonalizedHelpers.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>

--- a/TestApplication_PersonalizedHelpers.Tests/TestApplication_PersonalizedHelpers.Tests.csproj
+++ b/TestApplication_PersonalizedHelpers.Tests/TestApplication_PersonalizedHelpers.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_PersonalizedHelpers.Tests</RootNamespace>
     <AssemblyName>TestApplication_PersonalizedHelpers.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />

--- a/TestApplication_PersonalizedHelpers.Tests/packages.config
+++ b/TestApplication_PersonalizedHelpers.Tests/packages.config
@@ -16,5 +16,5 @@
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http.es" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>

--- a/TestApplication_PersonalizedHelpers/TestApplication_PersonalizedHelpers.csproj
+++ b/TestApplication_PersonalizedHelpers/TestApplication_PersonalizedHelpers.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_PersonalizedHelpers</RootNamespace>
     <AssemblyName>TestApplication_PersonalizedHelpers</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
@@ -63,9 +63,9 @@
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />

--- a/TestApplication_PersonalizedHelpers/TestApplication_PersonalizedHelpers.csproj
+++ b/TestApplication_PersonalizedHelpers/TestApplication_PersonalizedHelpers.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_PersonalizedHelpers</RootNamespace>
     <AssemblyName>TestApplication_PersonalizedHelpers</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />

--- a/TestApplication_PersonalizedHelpers/TestApplication_PersonalizedHelpers.csproj
+++ b/TestApplication_PersonalizedHelpers/TestApplication_PersonalizedHelpers.csproj
@@ -13,13 +13,16 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_PersonalizedHelpers</RootNamespace>
     <AssemblyName>TestApplication_PersonalizedHelpers</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <TargetFrameworkProfile />
+    <Use64BitIISExpress />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,16 +57,14 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
@@ -118,6 +119,7 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\SessionHelperStart.cs" />

--- a/TestApplication_PersonalizedHelpers/Web.config
+++ b/TestApplication_PersonalizedHelpers/Web.config
@@ -13,7 +13,7 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <connectionStrings>
-    <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
+    <add name="MongoSessionServices" connectionString="mongodb://localhost:27017" />
   </connectionStrings>
 
   <system.web>
@@ -50,4 +50,13 @@
       <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers></system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+
 </configuration>

--- a/TestApplication_PersonalizedHelpers/Web.config
+++ b/TestApplication_PersonalizedHelpers/Web.config
@@ -1,62 +1,63 @@
-﻿<?xml version="1.0" encoding="utf-8"?>   
+﻿<?xml version="1.0"?>
 <!--
   Para obtener más información sobre cómo configurar la aplicación de ASP.NET, visite
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
-
 <configuration>
   <appSettings>
-    <add key="webpages:Version" value="2.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="PreserveLoginUrl" value="true" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="webpages:Version" value="2.0.0.0"/>
+    <add key="webpages:Enabled" value="false"/>
+    <add key="PreserveLoginUrl" value="true"/>
+    <add key="ClientValidationEnabled" value="true"/>
+    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
   </appSettings>
   <connectionStrings>
-    <add name="MongoSessionServices" connectionString="mongodb://localhost:27017" />
+    <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
   </connectionStrings>
+  <!--
+    Para obtener una descripción de los cambios de web.config, vea http://go.microsoft.com/fwlink/?LinkId=235367.
 
+    Los siguientes atributos se pueden establecer en la etiqueta <httpRuntime>.
+      <system.Web>
+        <httpRuntime targetFramework="4.7.2" />
+      </system.Web>
+  -->
   <system.web>
-    
-    <httpRuntime targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5"/>
     <sessionState mode="Custom" customProvider="MongoSessionStateProvider">
       <providers>
-        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" />
+        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true"/>
       </providers>
     </sessionState>
-    
-    <compilation debug="true" targetFramework="4.5" />
-
+    <compilation debug="true" targetFramework="4.7.2"/>
     <pages>
       <namespaces>
-        <add namespace="System.Web.Helpers" />
-        <add namespace="System.Web.Mvc" />
-        <add namespace="System.Web.Mvc.Ajax" />
-        <add namespace="System.Web.Mvc.Html" />
-        <add namespace="System.Web.Routing" />
-        <add namespace="System.Web.WebPages" />
+        <add namespace="System.Web.Helpers"/>
+        <add namespace="System.Web.Mvc"/>
+        <add namespace="System.Web.Mvc.Ajax"/>
+        <add namespace="System.Web.Mvc.Html"/>
+        <add namespace="System.Web.Routing"/>
+        <add namespace="System.Web.WebPages"/>
       </namespaces>
     </pages>
   </system.web>
-
   <system.webServer>
-    <validation validateIntegratedModeConfiguration="false" />
-     
-  <handlers>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" />
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" />
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-    </handlers></system.webServer>
+    <validation validateIntegratedModeConfiguration="false"/>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit"/>
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0"/>
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+    </handlers>
+  </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-
 </configuration>

--- a/TestApplication_PersonalizedHelpers/Web.config
+++ b/TestApplication_PersonalizedHelpers/Web.config
@@ -29,7 +29,7 @@
         <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true"/>
       </providers>
     </sessionState>
-    <compilation debug="true" targetFramework="4.7.2"/>
+    <compilation debug="true" targetFramework="4.8"/>
     <pages>
       <namespaces>
         <add namespace="System.Web.Helpers"/>

--- a/TestApplication_PersonalizedHelpers/Web.config
+++ b/TestApplication_PersonalizedHelpers/Web.config
@@ -13,7 +13,7 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <connectionStrings>
-    <add name="MongoSessionServices" connectionString="mongodb://mongo1:27018,mongo1:27019,mongo1:27020/?connect=replicaset"/>
+    <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
   </connectionStrings>
 
   <system.web>

--- a/TestApplication_PersonalizedHelpers/packages.config
+++ b/TestApplication_PersonalizedHelpers/packages.config
@@ -20,5 +20,5 @@
   <package id="MongoDB.Bson" version="2.2.2" targetFramework="net45" />
   <package id="MongoDB.Driver" version="2.2.2" targetFramework="net45" />
   <package id="MongoDB.Driver.Core" version="2.2.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>

--- a/TestApplication_RAWSerialization.Tests/App.config
+++ b/TestApplication_RAWSerialization.Tests/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- 
     Note: Add entries to the App.config file for configuration settings
     that apply only to the Test project.
@@ -11,12 +11,12 @@
     <connectionStrings>
 
     </connectionStrings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TestApplication_RAWSerialization.Tests/App.config
+++ b/TestApplication_RAWSerialization.Tests/App.config
@@ -11,7 +11,7 @@
     <connectionStrings>
 
     </connectionStrings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/TestApplication_RAWSerialization.Tests/App.config
+++ b/TestApplication_RAWSerialization.Tests/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- 
     Note: Add entries to the App.config file for configuration settings
     that apply only to the Test project.
@@ -11,4 +11,13 @@
     <connectionStrings>
 
     </connectionStrings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/TestApplication_RAWSerialization.Tests/TestApplication_RAWSerialization.Tests.csproj
+++ b/TestApplication_RAWSerialization.Tests/TestApplication_RAWSerialization.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_RAWSerialization.Tests</RootNamespace>
     <AssemblyName>TestApplication_RAWSerialization.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />

--- a/TestApplication_RAWSerialization.Tests/TestApplication_RAWSerialization.Tests.csproj
+++ b/TestApplication_RAWSerialization.Tests/TestApplication_RAWSerialization.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_RAWSerialization.Tests</RootNamespace>
     <AssemblyName>TestApplication_RAWSerialization.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />

--- a/TestApplication_RAWSerialization.Tests/TestApplication_RAWSerialization.Tests.csproj
+++ b/TestApplication_RAWSerialization.Tests/TestApplication_RAWSerialization.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_RAWSerialization.Tests</RootNamespace>
     <AssemblyName>TestApplication_RAWSerialization.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />

--- a/TestApplication_RAWSerialization.Tests/packages.config
+++ b/TestApplication_RAWSerialization.Tests/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net40" requireReinstallation="true" />
 </packages>

--- a/TestApplication_RAWSerialization.Tests/packages.config
+++ b/TestApplication_RAWSerialization.Tests/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net40" />
 </packages>

--- a/TestApplication_RAWSerialization/TestApplication_RAWSerialization.csproj
+++ b/TestApplication_RAWSerialization/TestApplication_RAWSerialization.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_RAWSerialization</RootNamespace>
     <AssemblyName>TestApplication_RAWSerialization</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
@@ -21,6 +21,8 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <TargetFrameworkProfile />
+    <Use64BitIISExpress />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -53,9 +55,9 @@
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />

--- a/TestApplication_RAWSerialization/TestApplication_RAWSerialization.csproj
+++ b/TestApplication_RAWSerialization/TestApplication_RAWSerialization.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_RAWSerialization</RootNamespace>
     <AssemblyName>TestApplication_RAWSerialization</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />

--- a/TestApplication_RAWSerialization/TestApplication_RAWSerialization.csproj
+++ b/TestApplication_RAWSerialization/TestApplication_RAWSerialization.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_RAWSerialization</RootNamespace>
     <AssemblyName>TestApplication_RAWSerialization</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />

--- a/TestApplication_RAWSerialization/Web.config
+++ b/TestApplication_RAWSerialization/Web.config
@@ -12,7 +12,7 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
   </appSettings>
   <connectionStrings>
-    <add name="MongoSessionServices" connectionString="mongodb://mongo1:27018,mongo1:27019,mongo1:27020/?connect=replicaset"/>
+	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
   </connectionStrings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/TestApplication_RAWSerialization/Web.config
+++ b/TestApplication_RAWSerialization/Web.config
@@ -1,18 +1,18 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
   <appSettings>
-    <add key="webpages:Version" value="2.0.0.0"/>
-    <add key="webpages:Enabled" value="false"/>
-    <add key="PreserveLoginUrl" value="true"/>
-    <add key="ClientValidationEnabled" value="true"/>
-    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="webpages:Version" value="2.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="PreserveLoginUrl" value="true" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <connectionStrings>
-	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
+	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017" />
   </connectionStrings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -23,33 +23,41 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.5"/>
+    <compilation debug="true" targetFramework="4.5" />
     <sessionState mode="Custom" customProvider="MongoSessionStateProvider">
       <providers>
-        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" SerializationType="RAW" applicationName="RAWTestApplication"/>
+        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" SerializationType="RAW" applicationName="RAWTestApplication" />
       </providers>
     </sessionState>
     <pages controlRenderingCompatibilityVersion="4.0">
       <namespaces>
-        <add namespace="System.Web.Helpers"/>
-        <add namespace="System.Web.Mvc"/>
-        <add namespace="System.Web.Mvc.Ajax"/>
-        <add namespace="System.Web.Mvc.Html"/>
-        <add namespace="System.Web.Routing"/>
-        <add namespace="System.Web.WebPages"/>
+        <add namespace="System.Web.Helpers" />
+        <add namespace="System.Web.Mvc" />
+        <add namespace="System.Web.Mvc.Ajax" />
+        <add namespace="System.Web.Mvc.Html" />
+        <add namespace="System.Web.Routing" />
+        <add namespace="System.Web.WebPages" />
       </namespaces>
     </pages>
   </system.web>
   <system.webServer>
-    <validation validateIntegratedModeConfiguration="false"/>
-    <modules runAllManagedModulesForAllRequests="true"/>
+    <validation validateIntegratedModeConfiguration="false" />
+    <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit"/>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit"/>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0"/>
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" />
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" />
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
   </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/TestApplication_RAWSerialization/Web.config
+++ b/TestApplication_RAWSerialization/Web.config
@@ -23,7 +23,7 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.7.2"/>
+    <compilation debug="true" targetFramework="4.8"/>
     <sessionState mode="Custom" customProvider="MongoSessionStateProvider">
       <providers>
         <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" SerializationType="RAW" applicationName="RAWTestApplication"/>

--- a/TestApplication_RAWSerialization/Web.config
+++ b/TestApplication_RAWSerialization/Web.config
@@ -1,18 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
   <appSettings>
-    <add key="webpages:Version" value="2.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="PreserveLoginUrl" value="true" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="webpages:Version" value="2.0.0.0"/>
+    <add key="webpages:Enabled" value="false"/>
+    <add key="PreserveLoginUrl" value="true"/>
+    <add key="ClientValidationEnabled" value="true"/>
+    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
   </appSettings>
   <connectionStrings>
-	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017" />
+    <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
   </connectionStrings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -23,40 +23,40 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.5" />
+    <compilation debug="true" targetFramework="4.7.2"/>
     <sessionState mode="Custom" customProvider="MongoSessionStateProvider">
       <providers>
-        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" SerializationType="RAW" applicationName="RAWTestApplication" />
+        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" SerializationType="RAW" applicationName="RAWTestApplication"/>
       </providers>
     </sessionState>
     <pages controlRenderingCompatibilityVersion="4.0">
       <namespaces>
-        <add namespace="System.Web.Helpers" />
-        <add namespace="System.Web.Mvc" />
-        <add namespace="System.Web.Mvc.Ajax" />
-        <add namespace="System.Web.Mvc.Html" />
-        <add namespace="System.Web.Routing" />
-        <add namespace="System.Web.WebPages" />
+        <add namespace="System.Web.Helpers"/>
+        <add namespace="System.Web.Mvc"/>
+        <add namespace="System.Web.Mvc.Ajax"/>
+        <add namespace="System.Web.Mvc.Html"/>
+        <add namespace="System.Web.Routing"/>
+        <add namespace="System.Web.WebPages"/>
       </namespaces>
     </pages>
   </system.web>
   <system.webServer>
-    <validation validateIntegratedModeConfiguration="false" />
-    <modules runAllManagedModulesForAllRequests="true" />
+    <validation validateIntegratedModeConfiguration="false"/>
+    <modules runAllManagedModulesForAllRequests="true"/>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" />
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" />
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit"/>
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0"/>
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TestApplication_RAWSerialization/packages.config
+++ b/TestApplication_RAWSerialization/packages.config
@@ -10,5 +10,5 @@
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net40" />
 </packages>

--- a/TestApplication_RAWSerialization/packages.config
+++ b/TestApplication_RAWSerialization/packages.config
@@ -10,5 +10,5 @@
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net40" requireReinstallation="true" />
 </packages>

--- a/TestApplication_RAWSerializationWithoutTypeReference/TestApplication_RAWSerializationWithoutTypeReference.csproj
+++ b/TestApplication_RAWSerializationWithoutTypeReference/TestApplication_RAWSerializationWithoutTypeReference.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_PersonalizedHelpers</RootNamespace>
     <AssemblyName>TestApplication_RAWSerializationWithoutTypeReference</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />

--- a/TestApplication_RAWSerializationWithoutTypeReference/TestApplication_RAWSerializationWithoutTypeReference.csproj
+++ b/TestApplication_RAWSerializationWithoutTypeReference/TestApplication_RAWSerializationWithoutTypeReference.csproj
@@ -13,13 +13,16 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_PersonalizedHelpers</RootNamespace>
     <AssemblyName>TestApplication_RAWSerializationWithoutTypeReference</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <TargetFrameworkProfile />
+    <Use64BitIISExpress />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,16 +45,14 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
@@ -106,6 +107,7 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controllers\HomeController.cs" />

--- a/TestApplication_RAWSerializationWithoutTypeReference/TestApplication_RAWSerializationWithoutTypeReference.csproj
+++ b/TestApplication_RAWSerializationWithoutTypeReference/TestApplication_RAWSerializationWithoutTypeReference.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplication_PersonalizedHelpers</RootNamespace>
     <AssemblyName>TestApplication_RAWSerializationWithoutTypeReference</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
@@ -51,9 +51,9 @@
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />

--- a/TestApplication_RAWSerializationWithoutTypeReference/Web.config
+++ b/TestApplication_RAWSerializationWithoutTypeReference/Web.config
@@ -13,7 +13,7 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <connectionStrings>
-    <add name="MongoSessionServices" connectionString="mongodb://mongo1:27018,mongo1:27019,mongo1:27020/?connect=replicaset"/>
+	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
   </connectionStrings>
 
   <system.web>

--- a/TestApplication_RAWSerializationWithoutTypeReference/Web.config
+++ b/TestApplication_RAWSerializationWithoutTypeReference/Web.config
@@ -13,7 +13,7 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <connectionStrings>
-	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
+	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017" />
   </connectionStrings>
 
   <system.web>
@@ -23,7 +23,7 @@
     <compilation debug="true" targetFramework="4.5" />
     <sessionState mode="Custom" customProvider="MongoSessionStateProvider">
       <providers>
-        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" SerializationType="RAW" applicationName="RAWTestApplication"/>
+        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" SerializationType="RAW" applicationName="RAWTestApplication" />
       </providers>
     </sessionState>
 
@@ -50,4 +50,13 @@
       <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers></system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+
 </configuration>

--- a/TestApplication_RAWSerializationWithoutTypeReference/Web.config
+++ b/TestApplication_RAWSerializationWithoutTypeReference/Web.config
@@ -24,7 +24,7 @@
   -->
   <system.web>
     <httpRuntime targetFramework="4.5"/>
-    <compilation debug="true" targetFramework="4.7.2"/>
+    <compilation debug="true" targetFramework="4.8"/>
     <sessionState mode="Custom" customProvider="MongoSessionStateProvider">
       <providers>
         <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" SerializationType="RAW" applicationName="RAWTestApplication"/>

--- a/TestApplication_RAWSerializationWithoutTypeReference/Web.config
+++ b/TestApplication_RAWSerializationWithoutTypeReference/Web.config
@@ -1,62 +1,63 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
 <!--
   Para obtener más información sobre cómo configurar la aplicación de ASP.NET, visite
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
-
 <configuration>
   <appSettings>
-    <add key="webpages:Version" value="2.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="PreserveLoginUrl" value="true" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="webpages:Version" value="2.0.0.0"/>
+    <add key="webpages:Enabled" value="false"/>
+    <add key="PreserveLoginUrl" value="true"/>
+    <add key="ClientValidationEnabled" value="true"/>
+    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
   </appSettings>
   <connectionStrings>
-	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017" />
+    <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
   </connectionStrings>
+  <!--
+    Para obtener una descripción de los cambios de web.config, vea http://go.microsoft.com/fwlink/?LinkId=235367.
 
+    Los siguientes atributos se pueden establecer en la etiqueta <httpRuntime>.
+      <system.Web>
+        <httpRuntime targetFramework="4.7.2" />
+      </system.Web>
+  -->
   <system.web>
-    
-    <httpRuntime targetFramework="4.5" />
-    
-    <compilation debug="true" targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5"/>
+    <compilation debug="true" targetFramework="4.7.2"/>
     <sessionState mode="Custom" customProvider="MongoSessionStateProvider">
       <providers>
-        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" SerializationType="RAW" applicationName="RAWTestApplication" />
+        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="0" msWaitingForAttempt="500" AutoCreateTTLIndex="true" SerializationType="RAW" applicationName="RAWTestApplication"/>
       </providers>
     </sessionState>
-
     <pages>
       <namespaces>
-        <add namespace="System.Web.Helpers" />
-        <add namespace="System.Web.Mvc" />
-        <add namespace="System.Web.Mvc.Ajax" />
-        <add namespace="System.Web.Mvc.Html" />
-        <add namespace="System.Web.Routing" />
-        <add namespace="System.Web.WebPages" />
+        <add namespace="System.Web.Helpers"/>
+        <add namespace="System.Web.Mvc"/>
+        <add namespace="System.Web.Mvc.Ajax"/>
+        <add namespace="System.Web.Mvc.Html"/>
+        <add namespace="System.Web.Routing"/>
+        <add namespace="System.Web.WebPages"/>
       </namespaces>
     </pages>
   </system.web>
-
   <system.webServer>
-    <validation validateIntegratedModeConfiguration="false" />
-     
-  <handlers>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" />
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" />
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-    </handlers></system.webServer>
+    <validation validateIntegratedModeConfiguration="false"/>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit"/>
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0"/>
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+    </handlers>
+  </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-
 </configuration>

--- a/TestApplication_RAWSerializationWithoutTypeReference/packages.config
+++ b/TestApplication_RAWSerializationWithoutTypeReference/packages.config
@@ -17,5 +17,5 @@
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http.es" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>

--- a/TestApplicationv2_0.Tests/App.config
+++ b/TestApplicationv2_0.Tests/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- 
     Nota: agregue entradas al archivo App.config para la configuración de la aplicación
     que solo se apliquen al proyecto de prueba.
@@ -11,4 +11,12 @@
     <connectionStrings>
 
     </connectionStrings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/TestApplicationv2_0.Tests/App.config
+++ b/TestApplicationv2_0.Tests/App.config
@@ -19,4 +19,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/TestApplicationv2_0.Tests/App.config
+++ b/TestApplicationv2_0.Tests/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- 
     Nota: agregue entradas al archivo App.config para la configuración de la aplicación
     que solo se apliquen al proyecto de prueba.
@@ -14,9 +14,9 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/TestApplicationv2_0.Tests/TestApplicationv2_0.Tests.csproj
+++ b/TestApplicationv2_0.Tests/TestApplicationv2_0.Tests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplicationv2_0.Tests</RootNamespace>
     <AssemblyName>TestApplicationv2_0.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/TestApplicationv2_0.Tests/TestApplicationv2_0.Tests.csproj
+++ b/TestApplicationv2_0.Tests/TestApplicationv2_0.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplicationv2_0.Tests</RootNamespace>
     <AssemblyName>TestApplicationv2_0.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />

--- a/TestApplicationv2_0.Tests/TestApplicationv2_0.Tests.csproj
+++ b/TestApplicationv2_0.Tests/TestApplicationv2_0.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplicationv2_0.Tests</RootNamespace>
     <AssemblyName>TestApplicationv2_0.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>

--- a/TestApplicationv2_0.Tests/packages.config
+++ b/TestApplicationv2_0.Tests/packages.config
@@ -16,5 +16,5 @@
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http.es" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>

--- a/TestApplicationv2_0/TestApplicationv2_0.csproj
+++ b/TestApplicationv2_0/TestApplicationv2_0.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplicationv2_0</RootNamespace>
     <AssemblyName>TestApplicationv2_0</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />

--- a/TestApplicationv2_0/TestApplicationv2_0.csproj
+++ b/TestApplicationv2_0/TestApplicationv2_0.csproj
@@ -22,6 +22,7 @@
     <IISExpressUseClassicPipelineMode />
     <TargetFrameworkProfile />
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -79,9 +80,6 @@
     <Reference Include="Microsoft.Web.Mvc.FixedDisplayModes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.Mvc.FixedDisplayModes.1.0.0\lib\net40\Microsoft.Web.Mvc.FixedDisplayModes.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
     </Reference>

--- a/TestApplicationv2_0/TestApplicationv2_0.csproj
+++ b/TestApplicationv2_0/TestApplicationv2_0.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplicationv2_0</RootNamespace>
     <AssemblyName>TestApplicationv2_0</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />

--- a/TestApplicationv2_0/TestApplicationv2_0.csproj
+++ b/TestApplicationv2_0/TestApplicationv2_0.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestApplicationv2_0</RootNamespace>
     <AssemblyName>TestApplicationv2_0</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />

--- a/TestApplicationv2_0/Web.config
+++ b/TestApplicationv2_0/Web.config
@@ -1,18 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
 <!--
   Para obtener más información sobre cómo configurar la aplicación de ASP.NET, visite
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
   <appSettings>
-    <add key="webpages:Version" value="2.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="PreserveLoginUrl" value="true" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="webpages:Version" value="2.0.0.0"/>
+    <add key="webpages:Enabled" value="false"/>
+    <add key="PreserveLoginUrl" value="true"/>
+    <add key="ClientValidationEnabled" value="true"/>
+    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
   </appSettings>
   <connectionStrings>
-	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017" />
+    <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
   </connectionStrings>
   <!--
     Para obtener una descripción de los cambios de web.config, vea http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -25,38 +25,38 @@
   <system.web>
     <sessionState mode="Custom" customProvider="MongoSessionStateProvider">
       <providers>
-        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="220" msWaitingForAttempt="500" AutoCreateTTLIndex="true" />
+        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="220" msWaitingForAttempt="500" AutoCreateTTLIndex="true"/>
       </providers>
     </sessionState>
-    <httpRuntime />
-    <compilation debug="true" targetFramework="4.5" />
+    <httpRuntime/>
+    <compilation debug="true" targetFramework="4.7.2"/>
     <pages controlRenderingCompatibilityVersion="4.0">
       <namespaces>
-        <add namespace="System.Web.Helpers" />
-        <add namespace="System.Web.Mvc" />
-        <add namespace="System.Web.Mvc.Ajax" />
-        <add namespace="System.Web.Mvc.Html" />
-        <add namespace="System.Web.Routing" />
-        <add namespace="System.Web.WebPages" />
+        <add namespace="System.Web.Helpers"/>
+        <add namespace="System.Web.Mvc"/>
+        <add namespace="System.Web.Mvc.Ajax"/>
+        <add namespace="System.Web.Mvc.Html"/>
+        <add namespace="System.Web.Routing"/>
+        <add namespace="System.Web.WebPages"/>
       </namespaces>
     </pages>
   </system.web>
   <system.webServer>
-    <validation validateIntegratedModeConfiguration="false" />
+    <validation validateIntegratedModeConfiguration="false"/>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" />
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" />
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit"/>
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0"/>
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TestApplicationv2_0/Web.config
+++ b/TestApplicationv2_0/Web.config
@@ -1,18 +1,18 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   Para obtener más información sobre cómo configurar la aplicación de ASP.NET, visite
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
   <appSettings>
-    <add key="webpages:Version" value="2.0.0.0"/>
-    <add key="webpages:Enabled" value="false"/>
-    <add key="PreserveLoginUrl" value="true"/>
-    <add key="ClientValidationEnabled" value="true"/>
-    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="webpages:Version" value="2.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="PreserveLoginUrl" value="true" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <connectionStrings>
-	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
+	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017" />
   </connectionStrings>
   <!--
     Para obtener una descripción de los cambios de web.config, vea http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -25,31 +25,39 @@
   <system.web>
     <sessionState mode="Custom" customProvider="MongoSessionStateProvider">
       <providers>
-        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="220" msWaitingForAttempt="500" AutoCreateTTLIndex="true"/>
+        <add name="MongoSessionStateProvider" type="MongoSessionStateStore.MongoSessionStateStore" connectionStringName="MongoSessionServices" maxUpsertAttempts="220" msWaitingForAttempt="500" AutoCreateTTLIndex="true" />
       </providers>
     </sessionState>
-    <httpRuntime/>
-    <compilation debug="true" targetFramework="4.5"/>
+    <httpRuntime />
+    <compilation debug="true" targetFramework="4.5" />
     <pages controlRenderingCompatibilityVersion="4.0">
       <namespaces>
-        <add namespace="System.Web.Helpers"/>
-        <add namespace="System.Web.Mvc"/>
-        <add namespace="System.Web.Mvc.Ajax"/>
-        <add namespace="System.Web.Mvc.Html"/>
-        <add namespace="System.Web.Routing"/>
-        <add namespace="System.Web.WebPages"/>
+        <add namespace="System.Web.Helpers" />
+        <add namespace="System.Web.Mvc" />
+        <add namespace="System.Web.Mvc.Ajax" />
+        <add namespace="System.Web.Mvc.Html" />
+        <add namespace="System.Web.Routing" />
+        <add namespace="System.Web.WebPages" />
       </namespaces>
     </pages>
   </system.web>
   <system.webServer>
-    <validation validateIntegratedModeConfiguration="false"/>
+    <validation validateIntegratedModeConfiguration="false" />
     <handlers>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit"/>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit"/>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0"/>
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" />
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" />
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
   </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/TestApplicationv2_0/Web.config
+++ b/TestApplicationv2_0/Web.config
@@ -12,7 +12,7 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
   </appSettings>
   <connectionStrings>
-    <add name="MongoSessionServices" connectionString="mongodb://mongo1:27018,mongo1:27019,mongo1:27020/?connect=replicaset"/>
+	  <add name="MongoSessionServices" connectionString="mongodb://localhost:27017"/>
   </connectionStrings>
   <!--
     Para obtener una descripción de los cambios de web.config, vea http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/TestApplicationv2_0/Web.config
+++ b/TestApplicationv2_0/Web.config
@@ -29,7 +29,7 @@
       </providers>
     </sessionState>
     <httpRuntime/>
-    <compilation debug="true" targetFramework="4.7.2"/>
+    <compilation debug="true" targetFramework="4.8"/>
     <pages controlRenderingCompatibilityVersion="4.0">
       <namespaces>
         <add namespace="System.Web.Helpers"/>

--- a/TestApplicationv2_0/packages.config
+++ b/TestApplicationv2_0/packages.config
@@ -20,5 +20,5 @@
   <package id="MongoDB.Bson" version="2.2.2" targetFramework="net45" />
   <package id="MongoDB.Driver" version="2.2.2" targetFramework="net45" />
   <package id="MongoDB.Driver.Core" version="2.2.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>

--- a/TestApplicationv2_0/packages.config
+++ b/TestApplicationv2_0/packages.config
@@ -20,5 +20,4 @@
   <package id="MongoDB.Bson" version="2.2.2" targetFramework="net45" />
   <package id="MongoDB.Driver" version="2.2.2" targetFramework="net45" />
   <package id="MongoDB.Driver.Core" version="2.2.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This Pull Request updates the versions of the dependencies used by the test projects. Even though there was a reference to one of those libraries from the main project, there wasn’t any dependency on the code.

**There is no change in the .dll generated and there is no update on the project used to generate the .dll included in the package. Therefore, there is no reason to generate a new version of the package.** However, the reference has been removed just to avoid false alerts.

Also, all the test cases ran perfectly with versions 4.7.2 and 4.8 of .NET Framework consuming the session project built in version 4.5.2. 

As justified before, there is no new release and this PR is only for maintenance.